### PR TITLE
Unroll uint scans

### DIFF
--- a/delta_bitpacking.go
+++ b/delta_bitpacking.go
@@ -203,7 +203,7 @@ func deltaBitLenAndSignInt32(initoffset int32, buf []int32) (int, int) {
 	return bits.Len32(uint32(mask)) + sign, sign
 }
 
-// CompressDeltaBinPackUInt32 compress blocks of 128 integers from `in`
+// CompressDeltaBinPackUint32 compress blocks of 128 integers from `in`
 // and append to `out`. `out` slice will be resized if necessary.
 // The function returns the values from `in` that were not compressed (could
 // not fit into a block), and the updated `out` slice.
@@ -239,10 +239,10 @@ func CompressDeltaBinPackUint32(in, out []uint32) ([]uint32, []uint32) {
 		inblock2 := in[inpos+32 : inpos+64]
 		inblock3 := in[inpos+64 : inpos+96]
 		inblock4 := in[inpos+96 : inpos+128]
-		bitlen1, sign1 := deltaBitLenAndSignUint32(initoffset, inblock1)
-		bitlen2, sign2 := deltaBitLenAndSignUint32(inblock1[31], inblock2)
-		bitlen3, sign3 := deltaBitLenAndSignUint32(inblock2[31], inblock3)
-		bitlen4, sign4 := deltaBitLenAndSignUint32(inblock3[31], inblock4)
+		bitlen1, sign1 := deltaBitLenAndSignUint32(initoffset, (*[32]uint32)(inblock1))
+		bitlen2, sign2 := deltaBitLenAndSignUint32(inblock1[31], (*[32]uint32)(inblock2))
+		bitlen3, sign3 := deltaBitLenAndSignUint32(inblock2[31], (*[32]uint32)(inblock3))
+		bitlen4, sign4 := deltaBitLenAndSignUint32(inblock3[31], (*[32]uint32)(inblock4))
 
 		if outsize := bitlen1 + bitlen2 + bitlen3 + bitlen4; outpos+outsize+1 >= len(out) {
 			// no more space in out, realloc a bigger slice
@@ -381,14 +381,88 @@ func UncompressDeltaBinPackUint32(in, out []uint32) ([]uint32, []uint32) {
 	return in[inpos:], out[:outpos]
 }
 
-func deltaBitLenAndSignUint32(initoffset uint32, buf []uint32) (int, int) {
+func deltaBitLenAndSignUint32(initoffset uint32, buf *[32]uint32) (int, int) {
 	var mask uint32
 
-	for _, v := range buf {
-		diff := int32(v - initoffset)
-		// zigzag encoding
-		mask |= uint32((diff << 1) ^ (diff >> 31))
-		initoffset = v
+	{
+		const base = 0
+		d0 := int32(buf[base] - initoffset)
+		d1 := int32(buf[base+1] - buf[base])
+		d2 := int32(buf[base+2] - buf[base+1])
+		d3 := int32(buf[base+3] - buf[base+2])
+		m0 := uint32((d0<<1)^(d0>>31)) | uint32((d1<<1)^(d1>>31))
+		m1 := uint32((d2<<1)^(d2>>31)) | uint32((d3<<1)^(d3>>31))
+		mask = m0 | m1
+	}
+	{
+		const base = 4
+		d0 := int32(buf[base] - buf[base-1])
+		d1 := int32(buf[base+1] - buf[base])
+		d2 := int32(buf[base+2] - buf[base+1])
+		d3 := int32(buf[base+3] - buf[base+2])
+		m0 := uint32((d0<<1)^(d0>>31)) | uint32((d1<<1)^(d1>>31))
+		m1 := uint32((d2<<1)^(d2>>31)) | uint32((d3<<1)^(d3>>31))
+		mask |= m0 | m1
+	}
+	{
+		const base = 8
+		d0 := int32(buf[base] - buf[base-1])
+		d1 := int32(buf[base+1] - buf[base])
+		d2 := int32(buf[base+2] - buf[base+1])
+		d3 := int32(buf[base+3] - buf[base+2])
+		m0 := uint32((d0<<1)^(d0>>31)) | uint32((d1<<1)^(d1>>31))
+		m1 := uint32((d2<<1)^(d2>>31)) | uint32((d3<<1)^(d3>>31))
+		mask |= m0 | m1
+	}
+	{
+		const base = 12
+		d0 := int32(buf[base] - buf[base-1])
+		d1 := int32(buf[base+1] - buf[base])
+		d2 := int32(buf[base+2] - buf[base+1])
+		d3 := int32(buf[base+3] - buf[base+2])
+		m0 := uint32((d0<<1)^(d0>>31)) | uint32((d1<<1)^(d1>>31))
+		m1 := uint32((d2<<1)^(d2>>31)) | uint32((d3<<1)^(d3>>31))
+		mask |= m0 | m1
+	}
+	{
+		const base = 16
+		d0 := int32(buf[base] - buf[base-1])
+		d1 := int32(buf[base+1] - buf[base])
+		d2 := int32(buf[base+2] - buf[base+1])
+		d3 := int32(buf[base+3] - buf[base+2])
+		m0 := uint32((d0<<1)^(d0>>31)) | uint32((d1<<1)^(d1>>31))
+		m1 := uint32((d2<<1)^(d2>>31)) | uint32((d3<<1)^(d3>>31))
+		mask |= m0 | m1
+	}
+	{
+		const base = 20
+		d0 := int32(buf[base] - buf[base-1])
+		d1 := int32(buf[base+1] - buf[base])
+		d2 := int32(buf[base+2] - buf[base+1])
+		d3 := int32(buf[base+3] - buf[base+2])
+		m0 := uint32((d0<<1)^(d0>>31)) | uint32((d1<<1)^(d1>>31))
+		m1 := uint32((d2<<1)^(d2>>31)) | uint32((d3<<1)^(d3>>31))
+		mask |= m0 | m1
+	}
+	{
+		const base = 24
+		d0 := int32(buf[base] - buf[base-1])
+		d1 := int32(buf[base+1] - buf[base])
+		d2 := int32(buf[base+2] - buf[base+1])
+		d3 := int32(buf[base+3] - buf[base+2])
+		m0 := uint32((d0<<1)^(d0>>31)) | uint32((d1<<1)^(d1>>31))
+		m1 := uint32((d2<<1)^(d2>>31)) | uint32((d3<<1)^(d3>>31))
+		mask |= m0 | m1
+	}
+	{
+		const base = 28
+		d0 := int32(buf[base] - buf[base-1])
+		d1 := int32(buf[base+1] - buf[base])
+		d2 := int32(buf[base+2] - buf[base+1])
+		d3 := int32(buf[base+3] - buf[base+2])
+		m0 := uint32((d0<<1)^(d0>>31)) | uint32((d1<<1)^(d1>>31))
+		m1 := uint32((d2<<1)^(d2>>31)) | uint32((d3<<1)^(d3>>31))
+		mask |= m0 | m1
 	}
 	sign := int(mask & 1)
 	// remove sign in zigzag encoding
@@ -637,10 +711,10 @@ func CompressDeltaBinPackUint64(in, out []uint64) ([]uint64, []uint64) {
 		inblock2 := in[inpos+64 : inpos+128]
 		inblock3 := in[inpos+128 : inpos+192]
 		inblock4 := in[inpos+192 : inpos+256]
-		bitlen1, sign1 := deltaBitLenAndSignUint64(initoffset, inblock1)
-		bitlen2, sign2 := deltaBitLenAndSignUint64(inblock1[63], inblock2)
-		bitlen3, sign3 := deltaBitLenAndSignUint64(inblock2[63], inblock3)
-		bitlen4, sign4 := deltaBitLenAndSignUint64(inblock3[63], inblock4)
+		bitlen1, sign1 := deltaBitLenAndSignUint64(initoffset, (*[32]uint64)(inblock1))
+		bitlen2, sign2 := deltaBitLenAndSignUint64(inblock1[63], (*[32]uint64)(inblock2))
+		bitlen3, sign3 := deltaBitLenAndSignUint64(inblock2[63], (*[32]uint64)(inblock3))
+		bitlen4, sign4 := deltaBitLenAndSignUint64(inblock3[63], (*[32]uint64)(inblock4))
 
 		if outsize := bitlen1 + bitlen2 + bitlen3 + bitlen4; outpos+outsize+1 >= len(out) {
 			// no more space in out, realloc a bigger slice
@@ -780,15 +854,90 @@ func UncompressDeltaBinPackUint64(in, out []uint64) ([]uint64, []uint64) {
 	return in[inpos:], out[:outpos]
 }
 
-func deltaBitLenAndSignUint64(initoffset uint64, buf []uint64) (int, int) {
+func deltaBitLenAndSignUint64(initoffset uint64, buf *[32]uint64) (int, int) {
 	var mask uint64
 
-	for _, v := range buf {
-		diff := int64(v - initoffset)
-		// zigzag encoding
-		mask |= uint64((diff << 1) ^ (diff >> 63))
-		initoffset = v
+	{
+		const base = 0
+		d0 := int64(buf[base] - initoffset)
+		d1 := int64(buf[base+1] - buf[base])
+		d2 := int64(buf[base+2] - buf[base+1])
+		d3 := int64(buf[base+3] - buf[base+2])
+		m0 := uint64((d0<<1)^(d0>>31)) | uint64((d1<<1)^(d1>>31))
+		m1 := uint64((d2<<1)^(d2>>31)) | uint64((d3<<1)^(d3>>31))
+		mask = m0 | m1
 	}
+	{
+		const base = 4
+		d0 := int64(buf[base] - buf[base-1])
+		d1 := int64(buf[base+1] - buf[base])
+		d2 := int64(buf[base+2] - buf[base+1])
+		d3 := int64(buf[base+3] - buf[base+2])
+		m0 := uint64((d0<<1)^(d0>>31)) | uint64((d1<<1)^(d1>>31))
+		m1 := uint64((d2<<1)^(d2>>31)) | uint64((d3<<1)^(d3>>31))
+		mask |= m0 | m1
+	}
+	{
+		const base = 8
+		d0 := int64(buf[base] - buf[base-1])
+		d1 := int64(buf[base+1] - buf[base])
+		d2 := int64(buf[base+2] - buf[base+1])
+		d3 := int64(buf[base+3] - buf[base+2])
+		m0 := uint64((d0<<1)^(d0>>31)) | uint64((d1<<1)^(d1>>31))
+		m1 := uint64((d2<<1)^(d2>>31)) | uint64((d3<<1)^(d3>>31))
+		mask |= m0 | m1
+	}
+	{
+		const base = 12
+		d0 := int64(buf[base] - buf[base-1])
+		d1 := int64(buf[base+1] - buf[base])
+		d2 := int64(buf[base+2] - buf[base+1])
+		d3 := int64(buf[base+3] - buf[base+2])
+		m0 := uint64((d0<<1)^(d0>>31)) | uint64((d1<<1)^(d1>>31))
+		m1 := uint64((d2<<1)^(d2>>31)) | uint64((d3<<1)^(d3>>31))
+		mask |= m0 | m1
+	}
+	{
+		const base = 16
+		d0 := int64(buf[base] - buf[base-1])
+		d1 := int64(buf[base+1] - buf[base])
+		d2 := int64(buf[base+2] - buf[base+1])
+		d3 := int64(buf[base+3] - buf[base+2])
+		m0 := uint64((d0<<1)^(d0>>31)) | uint64((d1<<1)^(d1>>31))
+		m1 := uint64((d2<<1)^(d2>>31)) | uint64((d3<<1)^(d3>>31))
+		mask |= m0 | m1
+	}
+	{
+		const base = 20
+		d0 := int64(buf[base] - buf[base-1])
+		d1 := int64(buf[base+1] - buf[base])
+		d2 := int64(buf[base+2] - buf[base+1])
+		d3 := int64(buf[base+3] - buf[base+2])
+		m0 := uint64((d0<<1)^(d0>>31)) | uint64((d1<<1)^(d1>>31))
+		m1 := uint64((d2<<1)^(d2>>31)) | uint64((d3<<1)^(d3>>31))
+		mask |= m0 | m1
+	}
+	{
+		const base = 24
+		d0 := int64(buf[base] - buf[base-1])
+		d1 := int64(buf[base+1] - buf[base])
+		d2 := int64(buf[base+2] - buf[base+1])
+		d3 := int64(buf[base+3] - buf[base+2])
+		m0 := uint64((d0<<1)^(d0>>31)) | uint64((d1<<1)^(d1>>31))
+		m1 := uint64((d2<<1)^(d2>>31)) | uint64((d3<<1)^(d3>>31))
+		mask |= m0 | m1
+	}
+	{
+		const base = 28
+		d0 := int64(buf[base] - buf[base-1])
+		d1 := int64(buf[base+1] - buf[base])
+		d2 := int64(buf[base+2] - buf[base+1])
+		d3 := int64(buf[base+3] - buf[base+2])
+		m0 := uint64((d0<<1)^(d0>>31)) | uint64((d1<<1)^(d1>>31))
+		m1 := uint64((d2<<1)^(d2>>31)) | uint64((d3<<1)^(d3>>31))
+		mask |= m0 | m1
+	}
+
 	sign := int(mask & 1)
 	// remove sign in zigzag encoding
 	mask >>= 1


### PR DESCRIPTION
Unroll `deltaBitLenAndSignUintXX` and lazy merge result for better CPU pipelining.

```
benchmark                                                          old ns/op     new ns/op     delta
BenchmarkCompressDeltaBinPackUint32/nBits=0,_sign=0-32             224           78.9          -64.84%
BenchmarkCompressDeltaBinPackUint32/nBits=0,_sign=1-32             224           79.0          -64.82%
BenchmarkCompressDeltaBinPackUint32/nBits=1,_sign=0-32             286           157           -45.08%
BenchmarkCompressDeltaBinPackUint32/nBits=1,_sign=1-32             258           120           -53.60%
BenchmarkCompressDeltaBinPackUint32/nBits=2,_sign=0-32             285           150           -47.23%
BenchmarkCompressDeltaBinPackUint32/nBits=2,_sign=1-32             256           133           -48.01%
BenchmarkCompressDeltaBinPackUint32/nBits=3,_sign=0-32             290           142           -51.07%
BenchmarkCompressDeltaBinPackUint32/nBits=3,_sign=1-32             259           129           -50.19%
BenchmarkCompressDeltaBinPackUint32/nBits=4,_sign=0-32             295           136           -53.83%
BenchmarkCompressDeltaBinPackUint32/nBits=4,_sign=1-32             256           110           -56.95%
BenchmarkCompressDeltaBinPackUint32/nBits=5,_sign=0-32             291           143           -50.67%
BenchmarkCompressDeltaBinPackUint32/nBits=5,_sign=1-32             265           114           -56.82%
BenchmarkCompressDeltaBinPackUint32/nBits=6,_sign=0-32             290           143           -50.67%
BenchmarkCompressDeltaBinPackUint32/nBits=6,_sign=1-32             260           115           -55.90%
BenchmarkCompressDeltaBinPackUint32/nBits=7,_sign=0-32             295           169           -42.59%
BenchmarkCompressDeltaBinPackUint32/nBits=7,_sign=1-32             275           116           -57.72%
BenchmarkCompressDeltaBinPackUint32/nBits=8,_sign=0-32             280           135           -51.68%
BenchmarkCompressDeltaBinPackUint32/nBits=8,_sign=1-32             256           108           -57.89%
BenchmarkCompressDeltaBinPackUint32/nBits=9,_sign=0-32             315           150           -52.38%
BenchmarkCompressDeltaBinPackUint32/nBits=9,_sign=1-32             264           118           -55.34%
BenchmarkCompressDeltaBinPackUint32/nBits=10,_sign=0-32            298           149           -49.93%
BenchmarkCompressDeltaBinPackUint32/nBits=10,_sign=1-32            264           117           -55.77%
BenchmarkCompressDeltaBinPackUint32/nBits=11,_sign=0-32            322           155           -51.88%
BenchmarkCompressDeltaBinPackUint32/nBits=11,_sign=1-32            268           148           -44.90%
BenchmarkCompressDeltaBinPackUint32/nBits=12,_sign=0-32            299           170           -43.02%
BenchmarkCompressDeltaBinPackUint32/nBits=12,_sign=1-32            265           132           -50.23%
BenchmarkCompressDeltaBinPackUint32/nBits=13,_sign=0-32            310           161           -48.11%
BenchmarkCompressDeltaBinPackUint32/nBits=13,_sign=1-32            272           124           -54.50%
BenchmarkCompressDeltaBinPackUint32/nBits=14,_sign=0-32            313           156           -50.11%
BenchmarkCompressDeltaBinPackUint32/nBits=14,_sign=1-32            269           122           -54.77%
BenchmarkCompressDeltaBinPackUint32/nBits=15,_sign=0-32            304           161           -47.16%
BenchmarkCompressDeltaBinPackUint32/nBits=15,_sign=1-32            281           124           -55.93%
BenchmarkCompressDeltaBinPackUint32/nBits=16,_sign=0-32            276           149           -46.03%
BenchmarkCompressDeltaBinPackUint32/nBits=16,_sign=1-32            252           109           -56.90%
BenchmarkCompressDeltaBinPackUint32/nBits=17,_sign=0-32            313           186           -40.65%
BenchmarkCompressDeltaBinPackUint32/nBits=17,_sign=1-32            272           125           -53.97%
BenchmarkCompressDeltaBinPackUint32/nBits=18,_sign=0-32            328           164           -50.12%
BenchmarkCompressDeltaBinPackUint32/nBits=18,_sign=1-32            272           142           -47.69%
BenchmarkCompressDeltaBinPackUint32/nBits=19,_sign=0-32            318           168           -47.14%
BenchmarkCompressDeltaBinPackUint32/nBits=19,_sign=1-32            274           146           -46.82%
BenchmarkCompressDeltaBinPackUint32/nBits=20,_sign=0-32            308           187           -39.42%
BenchmarkCompressDeltaBinPackUint32/nBits=20,_sign=1-32            274           130           -52.59%
BenchmarkCompressDeltaBinPackUint32/nBits=21,_sign=0-32            319           197           -38.24%
BenchmarkCompressDeltaBinPackUint32/nBits=21,_sign=1-32            276           129           -53.44%
BenchmarkCompressDeltaBinPackUint32/nBits=22,_sign=0-32            334           173           -48.16%
BenchmarkCompressDeltaBinPackUint32/nBits=22,_sign=1-32            291           130           -55.51%
BenchmarkCompressDeltaBinPackUint32/nBits=23,_sign=0-32            324           175           -45.86%
BenchmarkCompressDeltaBinPackUint32/nBits=23,_sign=1-32            278           131           -52.82%
BenchmarkCompressDeltaBinPackUint32/nBits=24,_sign=0-32            326           186           -43.11%
BenchmarkCompressDeltaBinPackUint32/nBits=24,_sign=1-32            269           125           -53.64%
BenchmarkCompressDeltaBinPackUint32/nBits=25,_sign=0-32            328           185           -43.59%
BenchmarkCompressDeltaBinPackUint32/nBits=25,_sign=1-32            299           156           -47.93%
BenchmarkCompressDeltaBinPackUint32/nBits=26,_sign=0-32            322           178           -44.78%
BenchmarkCompressDeltaBinPackUint32/nBits=26,_sign=1-32            281           134           -52.33%
BenchmarkCompressDeltaBinPackUint32/nBits=27,_sign=0-32            337           208           -38.18%
BenchmarkCompressDeltaBinPackUint32/nBits=27,_sign=1-32            290           136           -53.36%
BenchmarkCompressDeltaBinPackUint32/nBits=28,_sign=0-32            322           201           -37.74%
BenchmarkCompressDeltaBinPackUint32/nBits=28,_sign=1-32            274           133           -51.33%
BenchmarkCompressDeltaBinPackUint32/nBits=29,_sign=0-32            341           192           -43.89%
BenchmarkCompressDeltaBinPackUint32/nBits=29,_sign=1-32            279           138           -50.59%
BenchmarkCompressDeltaBinPackUint32/nBits=30,_sign=0-32            331           208           -37.10%
BenchmarkCompressDeltaBinPackUint32/nBits=30,_sign=1-32            293           160           -45.42%
BenchmarkCompressDeltaBinPackUint32/nBits=31,_sign=0-32            353           222           -37.17%
BenchmarkCompressDeltaBinPackUint32/nBits=31,_sign=1-32            280           165           -40.90%
BenchmarkCompressDeltaBinPackUint32/nBits=32,_sign=0-32            356           219           -38.49%
BenchmarkCompressDeltaBinPackUint32/nBits=32,_sign=1-32            227           87.7          -61.31%
BenchmarkCompressDeltaBinPackUint64/nBits=0,_sign=0-32             390           79.1          -79.73%
BenchmarkCompressDeltaBinPackUint64/nBits=0,_sign=1-32             390           79.0          -79.76%
BenchmarkCompressDeltaBinPackUint64/nBits=1,_sign=0-32             515           200           -61.27%
BenchmarkCompressDeltaBinPackUint64/nBits=1,_sign=1-32             460           142           -69.22%
BenchmarkCompressDeltaBinPackUint64/nBits=2,_sign=0-32             512           237           -53.70%
BenchmarkCompressDeltaBinPackUint64/nBits=2,_sign=1-32             452           141           -68.76%
BenchmarkCompressDeltaBinPackUint64/nBits=3,_sign=0-32             511           202           -60.53%
BenchmarkCompressDeltaBinPackUint64/nBits=3,_sign=1-32             454           165           -63.69%
BenchmarkCompressDeltaBinPackUint64/nBits=4,_sign=0-32             506           240           -52.69%
BenchmarkCompressDeltaBinPackUint64/nBits=4,_sign=1-32             450           141           -68.70%
BenchmarkCompressDeltaBinPackUint64/nBits=5,_sign=0-32             512           217           -57.64%
BenchmarkCompressDeltaBinPackUint64/nBits=5,_sign=1-32             454           145           -68.05%
BenchmarkCompressDeltaBinPackUint64/nBits=6,_sign=0-32             511           236           -53.81%
BenchmarkCompressDeltaBinPackUint64/nBits=6,_sign=1-32             454           166           -63.32%
BenchmarkCompressDeltaBinPackUint64/nBits=7,_sign=0-32             517           215           -58.38%
BenchmarkCompressDeltaBinPackUint64/nBits=7,_sign=1-32             457           147           -67.72%
BenchmarkCompressDeltaBinPackUint64/nBits=8,_sign=0-32             505           232           -53.99%
BenchmarkCompressDeltaBinPackUint64/nBits=8,_sign=1-32             449           139           -68.97%
BenchmarkCompressDeltaBinPackUint64/nBits=9,_sign=0-32             519           228           -56.14%
BenchmarkCompressDeltaBinPackUint64/nBits=9,_sign=1-32             457           170           -62.74%
BenchmarkCompressDeltaBinPackUint64/nBits=10,_sign=0-32            515           206           -60.08%
BenchmarkCompressDeltaBinPackUint64/nBits=10,_sign=1-32            457           150           -67.24%
BenchmarkCompressDeltaBinPackUint64/nBits=11,_sign=0-32            521           260           -50.20%
BenchmarkCompressDeltaBinPackUint64/nBits=11,_sign=1-32            461           150           -67.48%
BenchmarkCompressDeltaBinPackUint64/nBits=12,_sign=0-32            513           206           -59.89%
BenchmarkCompressDeltaBinPackUint64/nBits=12,_sign=1-32            454           170           -62.54%
BenchmarkCompressDeltaBinPackUint64/nBits=13,_sign=0-32            524           263           -49.86%
BenchmarkCompressDeltaBinPackUint64/nBits=13,_sign=1-32            471           153           -67.55%
BenchmarkCompressDeltaBinPackUint64/nBits=14,_sign=0-32            533           252           -52.77%
BenchmarkCompressDeltaBinPackUint64/nBits=14,_sign=1-32            474           154           -67.52%
BenchmarkCompressDeltaBinPackUint64/nBits=15,_sign=0-32            555           245           -55.88%
BenchmarkCompressDeltaBinPackUint64/nBits=15,_sign=1-32            615           177           -71.25%
BenchmarkCompressDeltaBinPackUint64/nBits=16,_sign=0-32            966           234           -75.83%
BenchmarkCompressDeltaBinPackUint64/nBits=16,_sign=1-32            1518          139           -90.83%
BenchmarkCompressDeltaBinPackUint64/nBits=17,_sign=0-32            715           225           -68.50%
BenchmarkCompressDeltaBinPackUint64/nBits=17,_sign=1-32            592           165           -72.16%
BenchmarkCompressDeltaBinPackUint64/nBits=18,_sign=0-32            671           281           -58.15%
BenchmarkCompressDeltaBinPackUint64/nBits=18,_sign=1-32            606           194           -68.07%
BenchmarkCompressDeltaBinPackUint64/nBits=19,_sign=0-32            639           282           -55.84%
BenchmarkCompressDeltaBinPackUint64/nBits=19,_sign=1-32            490           177           -63.78%
BenchmarkCompressDeltaBinPackUint64/nBits=20,_sign=0-32            556           230           -58.63%
BenchmarkCompressDeltaBinPackUint64/nBits=20,_sign=1-32            481           182           -62.21%
BenchmarkCompressDeltaBinPackUint64/nBits=21,_sign=0-32            603           284           -52.89%
BenchmarkCompressDeltaBinPackUint64/nBits=21,_sign=1-32            894           162           -81.89%
BenchmarkCompressDeltaBinPackUint64/nBits=22,_sign=1-32            542           182           -66.40%
BenchmarkCompressDeltaBinPackUint64/nBits=23,_sign=0-32            632           248           -60.70%
BenchmarkCompressDeltaBinPackUint64/nBits=23,_sign=1-32            505           178           -64.78%
BenchmarkCompressDeltaBinPackUint64/nBits=24,_sign=0-32            577           264           -54.19%
BenchmarkCompressDeltaBinPackUint64/nBits=24,_sign=1-32            485           155           -67.97%
BenchmarkCompressDeltaBinPackUint64/nBits=25,_sign=0-32            574           280           -51.31%
BenchmarkCompressDeltaBinPackUint64/nBits=25,_sign=1-32            490           211           -57.01%
```