### PR TITLE
set ntz to 0 if sign is set for int64

### DIFF
--- a/delta_bitpacking.go
+++ b/delta_bitpacking.go
@@ -785,7 +785,7 @@ func deltaBitTzAndLenAndSignInt64(initoffset int64, inbuf []int64) (int, int, in
 	mask >>= 1
 
 	var ntz int
-	if mask != 0 {
+	if mask != 0 && sign == 0 {
 		ntz = bits.TrailingZeros64(mask)
 	}
 

--- a/delta_bitpacking_test.go
+++ b/delta_bitpacking_test.go
@@ -345,6 +345,43 @@ func TestCompressDeltaBinPackFullUint64(t *testing.T) {
 	}
 }
 
+func TestCompressIssue18(t *testing.T) {
+	testInput := []int64{
+		0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	}
+	notCompressed, c := intcomp.CompressDeltaBinPackInt64(testInput, nil)
+	if len(notCompressed) > 0 {
+		t.Fatal("notCompressed", notCompressed)
+	}
+	notUncompressed, out := intcomp.UncompressDeltaBinPackInt64(c, nil)
+	if len(notUncompressed) > 0 {
+		t.Fatal("notUncompressed", notUncompressed)
+	}
+	if len(testInput) != len(out) {
+		t.Fatalf("expected same len")
+	}
+	for i, v := range testInput {
+		if out[i] != v {
+			t.Fatalf("expected %d, got %d for index %d", v, out[i], i)
+		}
+	}
+}
+
 // BenchmarkCompressDeltaBinPackInt32 Benchmark compress one block: 128 x int32
 func BenchmarkCompressDeltaBinPackInt32(b *testing.B) {
 	rand.Seed(1) // nolint


### PR DESCRIPTION
The commit fixes a bug when compressing a set of int64 numbers where the ntz is greater than 0 but the set has a negative difference. In this circumstance the shift to trim the ntz bits was removing the sign needed to recover negative differences during decompression. This change fixes to issue by setting ntz to 0 if the set has a negative difference.

fixes ronanh/intcomp#18